### PR TITLE
Fix OpenFOAM Flatpak build

### DIFF
--- a/com.openfoam.OpenFOAM.yaml
+++ b/com.openfoam.OpenFOAM.yaml
@@ -1,5 +1,5 @@
 app-id: com.openfoam.OpenFOAM
-runtime: org.freedesktop.Sdk
+runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
 runtime-version: 24.08
 command: openfoam
@@ -9,8 +9,10 @@ finish-args:
   - --filesystem=home
 modules:
   - name: openmpi
-    cleanup:
-      - /bin
+    buildsystem: autotools
+    config-opts:
+      - --enable-mpi-cxx
+      - --disable-wrapper-runpath
     sources:
       - type: archive
         url: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.bz2
@@ -19,16 +21,30 @@ modules:
   - name: OpenFOAM
     build-options:
       env:
-        WM_PROJECT_DIR: /run/build/OpenFOAM
+        WM_PROJECT_DIR: /run/build/OpenFOAM/OpenFOAM-v2506
+        WM_THIRD_PARTY_DIR: /run/build/OpenFOAM/ThirdParty-v2506
     buildsystem: simple
     build-commands:
-      - echo $WM_PROJECT_DIR
-      - source etc/bashrc && echo $WM_PROJECT_DIR && ./Allwmake -j
-      - ls -l
-      - cp -r bin/* /app/bin
-      - cp -rp etc /app
-      - cp -rp platforms /app
+      - bash -lc "cd ThirdParty-v2506 && source ../OpenFOAM-v2506/etc/bashrc && ./Allwmake -j$(nproc)"
+      - bash -lc "cd OpenFOAM-v2506 && source etc/bashrc && ./Allwmake -j$(nproc)"
+      - install -d /app/OpenFOAM
+      - cp -a OpenFOAM-v2506 /app/OpenFOAM
+      - cp -a ThirdParty-v2506 /app/OpenFOAM
+      - install -d /app/bin
+      - cat <<'EOF' > /app/bin/openfoam
+#!/usr/bin/env bash
+source /app/OpenFOAM/OpenFOAM-v2506/etc/bashrc
+if [ $# -eq 0 ]; then
+  exec /usr/bin/bash -i
+else
+  exec "$@"
+fi
+EOF
+      - chmod +x /app/bin/openfoam
     sources:
       - type: archive
         url: https://dl.openfoam.com/source/v2506/OpenFOAM-v2506.tgz
         sha256: 63d26f48ae7ee9a7806a0ceb339ef8a0ba485a4714d54fbfb31e78e1a4849965
+      - type: archive
+        url: https://dl.openfoam.com/source/v2506/ThirdParty-v2506.tgz
+        sha256: 1f1d03e10e66a594f1ed916650f66be844eb5d2862cf73590d2bda9b4c6b9d73


### PR DESCRIPTION
## Summary
- build OpenMPI with autotools and keep its tooling available during the OpenFOAM build
- build both ThirdParty and OpenFOAM trees and install them into the app prefix
- add an entrypoint wrapper that sources the OpenFOAM environment before launching

## Testing
- Not run (flatpak-builder is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fe555c98288330904981917e0bdf5d