### PR TITLE
Update Flatpak build instructions for iRASPA

### DIFF
--- a/org.iraspa.iRASPA.yaml
+++ b/org.iraspa.iRASPA.yaml
@@ -28,8 +28,11 @@ modules:
           tag-pattern: ^(v[\d.]+)$
 
   - name: iRASPA-QT
-    buildsystem: cmake
+    buildsystem: cmake-ninja
+    builddir: _build
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
     sources:
-      - type: git
-        url: https://github.com/iRASPA/iRASPA-QT
-        tag: v2.3.2
+      - type: dir
+        path: iRASPA-QT


### PR DESCRIPTION
## Summary
- switch the iRASPA-QT module to the cmake-ninja buildsystem with an out-of-tree build directory
- disable tests for the build and reference the local submodule directory as the source

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f99bd5cfc8330b2bf0da86cb2face)